### PR TITLE
Fix: set back nodeLinker to `node-modules`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
-nodeLinker: pnpm
+nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.4.1.cjs


### PR DESCRIPTION
Reverting one of the changes done in #1 