### PR TITLE
Feat: Add refetch button to environment details card

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
@@ -22,7 +22,7 @@ import { Env0Icon } from '../env0-icon';
 
 type CardProps = {
   children: React.ReactNode;
-  onAction?: () => void;
+  retryAction?: () => void;
 };
 
 const VcsLinkContainer = styled('div')(() => ({
@@ -35,14 +35,14 @@ const StyledLink = styled(Link)(() => ({
   paddingLeft: '5px',
 }));
 
-const Env0Card = ({ children, onAction, ...rest }: CardProps) => (
+const Env0Card = ({ children, retryAction, ...rest }: CardProps) => (
   <InfoCard {...rest}>
     <CardHeader
       title="env0"
       avatar={<Env0Icon style={{ fontSize: 40 }} />}
       titleTypographyProps={{ variant: 'h5' }}
       action={
-        <Button onClick={onAction}>
+        <Button onClick={retryAction}>
           <Cached />
         </Button>
       }
@@ -57,7 +57,7 @@ export const Env0EnvironmentDetailsCard = () => {
   const environmentId =
     entity.metadata.annotations?.[ENV0_ENVIRONMENT_ANNOTATION];
 
-  const { value, loading, error } = useAsync(async () => {
+  const { value, loading, error, retry } = useAsync(async () => {
     if (isEmpty(environmentId)) {
       throw new Error("Entity's Environment ID is empty");
     }
@@ -73,14 +73,14 @@ export const Env0EnvironmentDetailsCard = () => {
   const { environment, template } = value ?? {};
   if (error) {
     return (
-      <Env0Card>
+      <Env0Card retryAction={retry}>
         <ErrorContainer error={error} />
       </Env0Card>
     );
   }
   if (loading || !environment || !template) {
     return (
-      <Env0Card>
+      <Env0Card retryAction={retry}>
         <Progress />
       </Env0Card>
     );
@@ -99,7 +99,7 @@ export const Env0EnvironmentDetailsCard = () => {
   );
 
   return (
-    <Env0Card onAction={() => retry()}>
+    <Env0Card retryAction={() => retry()}>
       <StructuredMetadataTable
         dense
         metadata={{

--- a/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useApi } from '@backstage/core-plugin-api';
 import { Env0Api } from '../../api/types';
-import useAsync from 'react-use/lib/useAsync';
+import useAsync from 'react-use/lib/useAsyncRetry';
 import { ErrorContainer } from '../common/error-container';
 import {
   InfoCard,
@@ -14,31 +14,38 @@ import isEmpty from 'lodash/isEmpty';
 import { getGitProvider, getShortenRepo } from './get-shorten-repo';
 import { VcsIcon } from './vcs-icon';
 import { env0ApiRef } from '../../api';
-import { CardHeader, styled } from '@material-ui/core';
+import { CardHeader, styled, Button } from '@material-ui/core';
+import Cached from '@material-ui/icons/Cached';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { ENV0_ENVIRONMENT_ANNOTATION } from '../common/is-plugin-available';
 import { Env0Icon } from '../env0-icon';
 
 type CardProps = {
   children: React.ReactNode;
+  onAction?: () => void;
 };
 
 const VcsLinkContainer = styled('div')(() => ({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center'
-}))
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+}));
 
 const StyledLink = styled(Link)(() => ({
-    paddingLeft: '5px'
-}))
+  paddingLeft: '5px',
+}));
 
-const Env0Card = ({ children, ...rest }: CardProps) => (
+const Env0Card = ({ children, onAction, ...rest }: CardProps) => (
   <InfoCard {...rest}>
     <CardHeader
       title="env0"
       avatar={<Env0Icon style={{ fontSize: 40 }} />}
       titleTypographyProps={{ variant: 'h5' }}
+      action={
+        <Button onClick={onAction}>
+          <Cached />
+        </Button>
+      }
     />
     {children}
   </InfoCard>
@@ -92,7 +99,7 @@ export const Env0EnvironmentDetailsCard = () => {
   );
 
   return (
-    <Env0Card>
+    <Env0Card onAction={() => retry()}>
       <StructuredMetadataTable
         dense
         metadata={{


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We want refetch button for environment details card


[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)

### Solution
Use `useAsyncRetry` instead of `useAsync`

https://github.com/user-attachments/assets/0dda73ba-ea95-4647-979a-3027e908b142

