### PR TITLE
Chore: Use error container for errors

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table.tsx
@@ -7,6 +7,7 @@ import { DeploymentType } from './deployment-type';
 import { formatDatetime, parseTimerElapsedTime } from './common/time.utils';
 import dayjs from './common/dayjs.types';
 import { DeploymentTableHeader } from './DeploymentTableHeader';
+import { ErrorContainer } from './common/error-container';
 
 const columnHeaderStyle = {
   color: '#3636D8',
@@ -69,7 +70,7 @@ export const Env0DeploymentTable: React.FunctionComponent<{
   } = useGetDeployments(environmentId);
 
   if (error) {
-    return <div>Error: {error.message}</div>;
+    return <ErrorContainer error={error} />;
   }
 
   return (

--- a/plugins/backstage-plugin-env0/src/components/env0-tab-component.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-tab-component.tsx
@@ -3,6 +3,7 @@ import { Content, Page } from '@backstage/core-components';
 import { Env0DeploymentTable } from './env0-deployment-table';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { ENV0_ENVIRONMENT_ANNOTATION } from './common/is-plugin-available';
+import { ErrorContainer } from './common/error-container';
 
 export const Env0TabComponent = () => {
   const { entity } = useEntity();
@@ -13,7 +14,7 @@ export const Env0TabComponent = () => {
     return (
       <Page themeId="tool">
         <Content>
-          <div>Environment ID not found</div>
+          <ErrorContainer error={new Error('No environment ID found')} />
         </Content>
       </Page>
     );


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We didn't use the common error container component when working on the deployment history

### Solution
Make it so that error messages go through our error container
![image](https://github.com/user-attachments/assets/edae6d7d-b785-4ec4-9ed8-f3745e2f49b6)
