### PR TITLE
Draft: `ui:*` custom field as isolated independent UI component

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-tab-component.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-tab-component.tsx
@@ -4,6 +4,7 @@ import { Env0DeploymentTable } from './env0-deployment-table/env0-deployment-tab
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { ENV0_ENVIRONMENT_ANNOTATION } from './common/is-plugin-available';
 import { ErrorContainer } from './common/error-container';
+import { Env0TemplateSelector } from './env0-template-selector/env0-template-selector';
 
 export const Env0TabComponent = () => {
   const { entity } = useEntity();
@@ -24,6 +25,24 @@ export const Env0TabComponent = () => {
     <Page themeId="tool">
       <Content>
         <Env0DeploymentTable environmentId={environmentId} />
+        <div style={{ border: '1px solid red' }}>
+          <p>
+            This is a ui:* custom field implemented originally for the
+            template.yaml. Now render it as isolated component on the entity
+            page:
+          </p>
+          <Env0TemplateSelector
+            onChange={templateId =>
+              console.log(`Selected Template: ${templateId}`)
+            }
+            schema={{
+              title: 'Select a Template',
+            }}
+            rawErrors={[]}
+            required={true}
+            formData={undefined}
+          />
+        </div>
       </Content>
     </Page>
   );

--- a/plugins/backstage-plugin-env0/src/components/env0-template-selector/env0-template-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-template-selector/env0-template-selector.tsx
@@ -19,6 +19,7 @@ const Env0TemplateSelectorFieldSchema = makeFieldSchema({
 
 export const Env0TemplateSelectorSchema =
   Env0TemplateSelectorFieldSchema.schema;
+
 type Env0TemplateSelectorFieldProps =
   typeof Env0TemplateSelectorFieldSchema.type;
 
@@ -28,7 +29,10 @@ export const Env0TemplateSelector = ({
   rawErrors,
   required,
   formData: selectedTemplateId,
-}: Env0TemplateSelectorFieldProps) => {
+}: Pick<
+  Env0TemplateSelectorFieldProps,
+  'onChange' | 'schema' | 'rawErrors' | 'required' | 'formData'
+>) => {
   const api = useApi<Env0Api>(env0ApiRef);
   const [isErrorOpen, setIsErrorOpen] = useState<boolean>(true);
   const { value, loading, error } = useAsync(async () => {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)

### Solution
proved it is possible to reuse a custom form field that was originally developed for the `template.yaml`, aka `ui:*` custom fields.

### QA
![image](https://github.com/user-attachments/assets/7110e931-88f3-4836-924b-732f103a11f4)

[//]: # (Explain how you tested this PR)