### PR TITLE
Feat: actually show env details

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -59,7 +59,11 @@ import {
   isKubernetesAvailable,
 } from '@backstage/plugin-kubernetes';
 
-import { Env0TabComponent, isEnv0Available } from '@env0/backstage-plugin-env0';
+import {
+  Env0TabComponent,
+  isEnv0Available,
+  Env0EnvironmentDetailsCard,
+} from '@env0/backstage-plugin-env0';
 
 const techdocsContent = (
   <EntityTechdocsContent>
@@ -131,21 +135,9 @@ const entityWarningContent = (
 );
 
 const overviewContent = (
-  <Grid container spacing={3} alignItems="stretch">
+  <Grid spacing={3} alignItems="stretch">
     {entityWarningContent}
-    <Grid item md={6}>
-      <EntityAboutCard variant="gridItem" />
-    </Grid>
-    <Grid item md={6} xs={12}>
-      <EntityCatalogGraphCard variant="gridItem" height={400} />
-    </Grid>
-
-    <Grid item md={4} xs={12}>
-      <EntityLinksCard />
-    </Grid>
-    <Grid item md={8} xs={12}>
-      <EntityHasSubcomponentsCard variant="gridItem" />
-    </Grid>
+    <Env0EnvironmentDetailsCard />
   </Grid>
 );
 

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -135,10 +135,10 @@ const entityWarningContent = (
 );
 
 const overviewContent = (
-  <Grid spacing={3} alignItems="stretch">
+  <>
     {entityWarningContent}
     <Env0EnvironmentDetailsCard />
-  </Grid>
+  </>
 );
 
 const serviceEntityPage = (

--- a/plugins/backstage-plugin-env0/src/index.ts
+++ b/plugins/backstage-plugin-env0/src/index.ts
@@ -1,3 +1,8 @@
-export { backstagePluginEnv0Plugin, BackstagePluginEnv0Page, Env0TemplateSelectorExtension } from './plugin';
+export {
+  backstagePluginEnv0Plugin,
+  BackstagePluginEnv0Page,
+  Env0TemplateSelectorExtension,
+} from './plugin';
 export * from './components/common/is-plugin-available';
 export { Env0TabComponent } from './components/env0-tab-component';
+export { Env0EnvironmentDetailsCard } from './components/env0-environment-details-card';


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We need to show the context's environment details in the overview tab
### Solution
mount it instead of the boilerplate UI there
### QA
<img width="1728" alt="Screenshot 2024-12-12 at 10 58 59" src="https://github.com/user-attachments/assets/4f3d0609-3a80-41d9-82d3-cb295589fb7b" />

[//]: # (Explain how you tested this PR)