### PR TITLE
Chore: Filter out secret ref variables

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -113,11 +113,6 @@ const variableInputByInputType: Record<
 
 const shouldShowVariable = (variable: Variable) => {
   if (secretTypeReferences.some(ref => variable.value?.includes(ref))) {
-    if (variable.isRequired) {
-      throw new Error(
-        "Not supported: variable of type secrets reference can't be required",
-      );
-    }
     return false;
   }
 

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -114,12 +114,26 @@ const variableInputByInputType: Record<
 const shouldShowVariable = (variable: Variable) => {
   if (secretTypeReferences.some(ref => variable.value?.includes(ref))) {
     if (variable.isRequired) {
-      throw new Error("Not supported: variable of type secrets reference can't be required");
+      throw new Error(
+        "Not supported: variable of type secrets reference can't be required",
+      );
     }
     return false;
   }
 
   return !(variable.isReadonly || variable.isOutput);
+};
+
+const areVariablesValid = (variables: Variable[]) => {
+  variables.forEach(variable => {
+    if (secretTypeReferences.some(ref => variable.value?.includes(ref))) {
+      if (variable.isRequired) {
+        throw new Error(
+          "Not supported: variable of type secrets reference can't be required",
+        );
+      }
+    }
+  });
 };
 
 export const Env0VariablesInput = ({
@@ -165,6 +179,14 @@ export const Env0VariablesInput = ({
         <ErrorContainer error={error} />
       </Env0Card>
     );
+  }
+
+  try {
+    areVariablesValid(variables);
+  } catch (e) {
+    return (<Env0Card title="env0" retryAction={retry}>
+      <ErrorContainer error={e as Error} />
+    </Env0Card>)
   }
 
   const updateVariableValue = (index: number, value: string) => {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We don't support `ssm, gcp, azure, vault` secret references since the developer have nothing to do with it.
If there is such variable and it is required throw unsupported error

### Solution
Filter it out
### QA

- [x] Created such variable and saw we don't show it
- [x] Created such variable with required saw error

![image](https://github.com/user-attachments/assets/6babce50-7298-494e-b074-09f4e24d6a26)
