### PR TITLE
Fix: PR title validate needs reset every commit

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -5,6 +5,7 @@ on:
       - "opened"
       - "edited"
       - "reopened"
+      - "synchronize"
 jobs:
   check-title:
     name: "PR Title"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
The commit check is attached to commit and before merge we need to rerun the validate action to get the check on the latest commit 

### Solution
Run in on `synchronize` events

### QA

[//]: # (Explain how you tested this PR)