### PR TITLE
Chore: Extract variables input to general one

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -7,18 +7,16 @@ import { ErrorContainer } from '../common/error-container';
 import { FormControl } from '@material-ui/core';
 import { Env0VariableField } from './env0-variable-field';
 
-
 const shouldShowVariable = (variable: Variable) =>
-    !(variable.isReadonly || variable.isOutput);
-
+  !(variable.isReadonly || variable.isOutput);
 
 export type Env0VariablesInputProps = {
-    projectId?: string;
-    templateId?: string;
-    environmentId?: string;
-    onVariablesChange: (update: Variable[]) => void;
-    rawErrors: string[];
-    initialVariables: Variable[];
+  projectId?: string;
+  templateId?: string;
+  environmentId?: string;
+  onVariablesChange: (update: Variable[]) => void;
+  rawErrors: string[];
+  initialVariables: Variable[];
 };
 
 export const Env0VariablesInput = ({

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -1,56 +1,35 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';
-import { FormControl } from '@material-ui/core';
+import type { Variable } from '../../api/types';
 import { useVariablesDataByTemplate } from '../../hooks/use-variables-data-by-template';
+import { Env0Card } from '../common/env0-card';
 import { Progress } from '@backstage/core-components';
 import { ErrorContainer } from '../common/error-container';
-import { Env0Card } from '../common/env0-card';
-
-import { z } from 'zod';
-import type { Variable } from '../../api/types';
+import { FormControl } from '@material-ui/core';
 import { Env0VariableField } from './env0-variable-field';
 
-const variableSchema = (zImpl: typeof z) =>
-  zImpl
-    .object({
-      name: zImpl.string(),
-      value: zImpl.string().optional(),
-    })
-    .passthrough();
-
-const Env0VariableInputFieldSchema = makeFieldSchema({
-  output: zImpl => zImpl.array(variableSchema(zImpl)),
-  uiOptions: zImpl => zImpl.object({}),
-});
-
-export const Env0VariableInputSchema = Env0VariableInputFieldSchema.schema;
-
-type PassedFormContextFields = {
-  formData: {
-    env0_project_id?: string;
-    env0_template_id?: string;
-  };
-};
-
-type Env0TemplateSelectorFieldProps =
-  typeof Env0VariableInputFieldSchema.TProps;
 
 const shouldShowVariable = (variable: Variable) =>
-  !(variable.isReadonly || variable.isOutput);
+    !(variable.isReadonly || variable.isOutput);
+
+
+export type Env0VariablesInputProps = {
+    projectId?: string;
+    templateId?: string;
+    environmentId?: string;
+    onVariablesChange: (update: Variable[]) => void;
+    rawErrors: string[];
+    initialVariables: Variable[];
+};
 
 export const Env0VariablesInput = ({
-  formData = [],
-  formContext,
+  projectId,
+  templateId,
+  environmentId,
+  onVariablesChange,
   rawErrors,
-  onChange: onVariablesChange,
-}: Env0TemplateSelectorFieldProps): React.ReactElement => {
-  const {
-    formData: { env0_project_id: projectId, env0_template_id: templateId },
-  } = formContext as PassedFormContextFields;
-
-  const [variables, setVariables] = useState<Variable[]>(
-    formData as Variable[],
-  );
+  initialVariables,
+}: Env0VariablesInputProps) => {
+  const [variables, setVariables] = useState<Variable[]>(initialVariables);
 
   const onVariablesChangeCallback = useCallback(
     (newVariables: Variable[]) => {
@@ -67,7 +46,7 @@ export const Env0VariablesInput = ({
     error,
     value: variablesData,
     retry,
-  } = useVariablesDataByTemplate(templateId, projectId);
+  } = useVariablesDataByTemplate(templateId, projectId, environmentId);
 
   useEffect(() => {
     if (variablesData && !isInitialized) {

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';
+import { z } from 'zod';
+import type { Variable } from '../../api/types';
+import {Env0VariablesInput} from "./env0-variables-input";
+
+const variableSchema = (zImpl: typeof z) =>
+  zImpl
+    .object({
+      name: zImpl.string(),
+      value: zImpl.string().optional(),
+    })
+    .passthrough();
+
+const Env0VariableInputFieldSchema = makeFieldSchema({
+  output: zImpl => zImpl.array(variableSchema(zImpl)),
+  uiOptions: zImpl => zImpl.object({}),
+});
+
+export const Env0VariableInputSchema = Env0VariableInputFieldSchema.schema;
+
+type PassedFormContextFields = {
+  formData: {
+    env0_project_id?: string;
+    env0_template_id?: string;
+  };
+};
+
+type Env0TemplateSelectorFieldProps =
+  typeof Env0VariableInputFieldSchema.TProps;
+
+
+export const Env0VariablesScaffolderInput = ({
+  formContext,
+  formData = [],
+  rawErrors,
+  onChange: onVariablesChange,
+}: Env0TemplateSelectorFieldProps): React.ReactElement => {
+  const {
+    formData: { env0_project_id: projectId, env0_template_id: templateId },
+  } = formContext as PassedFormContextFields;
+  return (
+    <Env0VariablesInput
+      {...{
+        initialVariables: formData as Variable[],
+        onVariablesChange,
+        rawErrors,
+        projectId,
+        templateId,
+      }}
+    />
+  );
+};

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
@@ -40,13 +40,11 @@ export const Env0VariablesScaffolderInput = ({
   } = formContext as PassedFormContextFields;
   return (
     <Env0VariablesInput
-      {...{
-        initialVariables: formData as Variable[],
-        onVariablesChange,
-        rawErrors,
-        projectId,
-        templateId,
-      }}
+      initialVariables={formData as Variable[]}
+      onVariablesChange={onVariablesChange}
+      rawErrors={rawErrors}
+      projectId={projectId}
+      templateId={templateId}
     />
   );
 };

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';
 import { z } from 'zod';
 import type { Variable } from '../../api/types';
-import {Env0VariablesInput} from "./env0-variables-input";
+import { Env0VariablesInput } from './env0-variables-input';
 
 const variableSchema = (zImpl: typeof z) =>
   zImpl
@@ -28,7 +28,6 @@ type PassedFormContextFields = {
 
 type Env0TemplateSelectorFieldProps =
   typeof Env0VariableInputFieldSchema.TProps;
-
 
 export const Env0VariablesScaffolderInput = ({
   formContext,

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/index.ts
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/index.ts
@@ -1,1 +1,2 @@
+export * from './env0-variables-scaffolder-input';
 export * from './env0-variables-input';

--- a/plugins/backstage-plugin-env0/src/hooks/use-variables-data-by-template.tsx
+++ b/plugins/backstage-plugin-env0/src/hooks/use-variables-data-by-template.tsx
@@ -5,6 +5,7 @@ import { useAsyncRetry } from 'react-use';
 export const useVariablesDataByTemplate = (
   templateId?: string,
   projectId?: string,
+  environmentId?: string
 ) => {
   const apiClient = useApi<Env0Api>(env0ApiRef);
 
@@ -18,6 +19,7 @@ export const useVariablesDataByTemplate = (
     const template = await apiClient.getTemplateById(templateId);
 
     return await apiClient.listVariables({
+      environmentId,
       projectId,
       blueprintId: templateId,
       organizationId: template.organizationId,

--- a/plugins/backstage-plugin-env0/src/plugin.ts
+++ b/plugins/backstage-plugin-env0/src/plugin.ts
@@ -20,7 +20,7 @@ import {
 } from './components/env0-project-selector';
 import {
   Env0VariableInputSchema,
-  Env0VariablesInput,
+  Env0VariablesScaffolderInput,
 } from './components/env0-variables-input';
 
 export const backstagePluginEnv0Plugin = createPlugin({
@@ -65,7 +65,7 @@ export const Env0ProjectSelectorExtension = scaffolderPlugin.provide(
 export const Env0VariableInputExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
     name: 'Env0VariablesInput',
-    component: Env0VariablesInput,
+    component: Env0VariablesScaffolderInput,
     schema: Env0VariableInputSchema,
   }),
 );


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We would like to mount `Env0VariablesInput` in other places not in the scaffolder form

### Solution
Extract what not related to the form to a different component
Call the extracted component with destructed props

### QA
Did the create flow and saw we are good