### PR TITLE
Chore: fix auto complete filter results

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
@@ -106,6 +106,9 @@ export const Env0ProjectSelector = ({
           onChange={(_, newValue: Project | null) => {
             onProjectIdChange(newValue?.id);
           }}
+          renderOption={(props, option) => (
+              <li {...props} key={option.id}>{option.name}</li>
+          )}
           renderInput={params => (
             <TextField
               {...params}

--- a/plugins/backstage-plugin-env0/src/components/env0-template-selector/env0-template-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-template-selector/env0-template-selector.tsx
@@ -68,6 +68,9 @@ export const Env0TemplateSelector = ({
           onChange={(_, newValue: Template | null) => {
             onTemplateIdChange(newValue?.id);
           }}
+          renderOption={(props, option) => (
+              <li {...props} key={option.id}>{option.name}</li>
+          )}
           renderInput={params => (
             <TextField
               {...params}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
When we searched specific text the values form the auto complete were wrong 

### Solution
Found the exact issue - [Fixing Material UI Autocomplete Search As You Type | Lockstep](https://lockstep.io/blog/debugging-lesson-well-learned-fixing-material-ui-autocomplete-search/)
### QA

[//]: # (Explain how you tested this PR)

Saw we actually filter correctly now

Before - 
<img width="307" alt="image" src="https://github.com/user-attachments/assets/178f302f-18a0-48a6-8ee9-5ba5d0896e3d" />

After - 
<img width="330" alt="image" src="https://github.com/user-attachments/assets/930da9de-8c50-4e11-a32a-e85ca71b4fd4" />
