### PR TITLE
Feat: add env0 link in environment details card

### DIFF
--- a/plugins/backstage-plugin-env0/src/api/types.d.ts
+++ b/plugins/backstage-plugin-env0/src/api/types.d.ts
@@ -81,6 +81,7 @@ export type EnvironmentDriftStatus =
   | 'DISABLED';
 
 export type Environment = {
+  id: string;
   name: string;
   status: EnvironmentStatus;
   driftStatus: EnvironmentDriftStatus;

--- a/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
@@ -16,6 +16,22 @@ import { ENV0_ENVIRONMENT_ANNOTATION } from '../common/is-plugin-available';
 import { VcsIcon } from './vcs-icon';
 import Status from '../env0-status/status';
 import { Env0Card } from '../common/env0-card';
+import CardActions from '@mui/material/CardActions';
+import Button from '@mui/material/Button';
+
+const getEnv0AppUrl = () => {
+  return process.env.ENV0_APP_URL ?? 'https://app.env0.com';
+};
+
+export const getEnv0EnvironmentUrl = ({
+  environmentId,
+  projectId,
+}: {
+  environmentId: string;
+  projectId: string;
+}) => {
+  return `${getEnv0AppUrl()}/p/${projectId}/environments/${environmentId}`;
+};
 
 const VcsLinkContainer = styled('div')(() => ({
   display: 'flex',
@@ -89,6 +105,16 @@ export const Env0EnvironmentDetailsCard = () => {
           createdBy: environment.user.name,
         }}
       />
+      <CardActions>
+        <Button color="primary" variant="contained">
+          <Link
+            to={getEnv0EnvironmentUrl({ environmentId: environment.id, projectId: environment.projectId })}
+            color="textPrimary"
+          >
+            Open in env0
+          </Link>
+        </Button>
+      </CardActions>
     </Env0Card>
   );
 };


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We need "Open in env0" button in the footer of the environment details card
### Solution
Add it 

### QA
Button that contains a link
![image](https://github.com/user-attachments/assets/cd3f6a81-e8f6-4d59-9bad-21c70caed64e)

Actual link
![image](https://github.com/user-attachments/assets/0ec3a618-64f6-4a71-8286-6a06e6b42598)
![image](https://github.com/user-attachments/assets/3d7e740d-50f9-469d-9acc-8a638435cf12)
