### PR TITLE
Fix: Disable redeploy button on redeploy

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
@@ -41,7 +41,7 @@ export const RedeployButton: React.FC<{
 
   const api = useApi<Env0Api>(env0ApiRef);
   const [snackbarText, setSnackbarText] = useState<string>('');
-  const [isRedeploy, setIsRedeploy] = useState<boolean>(false);
+  const [isRedeploying, setIsRedeploying] = useState<boolean>(false);
   const [snackBarOpen, setSnackBarOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [variables, setVariables] = useState<Variable[]>([]);
@@ -88,7 +88,7 @@ export const RedeployButton: React.FC<{
     }
 
     try {
-      setIsRedeploy(true);
+      setIsRedeploying(true);
       await api.redeployEnvironment(environmentId, variables);
       setSnackbarText('env0 deployment initiated successfully ✅');
     } catch (error) {
@@ -96,12 +96,12 @@ export const RedeployButton: React.FC<{
     } finally {
       setSnackBarOpen(true);
       setModalOpen(false);
-      setIsRedeploy(false);
+      setIsRedeploying(false);
       afterDeploy?.();
     }
   };
 
-  const deployButtonText = isRedeploy ? (
+  const deployButtonText = isRedeploying ? (
     <span>
       <CircularProgress size="1em" /> Loading...
     </span>
@@ -132,7 +132,7 @@ export const RedeployButton: React.FC<{
               color="primary"
               variant="contained"
               onClick={() => handleRedeploy()}
-              disabled={isRedeploy}
+              disabled={isRedeploying}
             >
               {deployButtonText}
             </Button>

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
@@ -41,7 +41,7 @@ export const RedeployButton: React.FC<{
 
   const api = useApi<Env0Api>(env0ApiRef);
   const [snackbarText, setSnackbarText] = useState<string>('');
-  const [isRedeployLoading, setRedeployLoading] = useState<boolean>(false);
+  const [isRedeploy, setIsRedeploy] = useState<boolean>(false);
   const [snackBarOpen, setSnackBarOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [variables, setVariables] = useState<Variable[]>([]);
@@ -88,7 +88,7 @@ export const RedeployButton: React.FC<{
     }
 
     try {
-      setRedeployLoading(true);
+      setIsRedeploy(true);
       await api.redeployEnvironment(environmentId, variables);
       setSnackbarText('env0 deployment initiated successfully ✅');
     } catch (error) {
@@ -96,12 +96,12 @@ export const RedeployButton: React.FC<{
     } finally {
       setSnackBarOpen(true);
       setModalOpen(false);
-      setRedeployLoading(false);
+      setIsRedeploy(false);
       afterDeploy?.();
     }
   };
 
-  const deployButtonText = isRedeployLoading ? (
+  const deployButtonText = isRedeploy ? (
     <span>
       <CircularProgress size="1em" /> Loading...
     </span>
@@ -132,6 +132,7 @@ export const RedeployButton: React.FC<{
               color="primary"
               variant="contained"
               onClick={() => handleRedeploy()}
+              disabled={isRedeploy}
             >
               {deployButtonText}
             </Button>


### PR DESCRIPTION
Signed-off-by: elbaz <eranelbaz97+github@gmail.com>

### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
When you redeploy an environment the redeploy button was still clickable and you could spam the deploy api
### Solution
disable when we redeploy by the hook we use for loading
### QA

[//]: # (Explain how you tested this PR)
![image](https://github.com/user-attachments/assets/26ff1d29-83b1-4f38-93a4-c9213287c8e9)


