### PR TITLE
Fix: Hide output variables

### DIFF
--- a/plugins/backstage-plugin-env0/src/api/types.d.ts
+++ b/plugins/backstage-plugin-env0/src/api/types.d.ts
@@ -150,7 +150,6 @@ type VariableFields = {
   isSensitive?: boolean;
   isReadonly?: boolean;
   isRequired?: boolean;
-  isOutput?: boolean;
   regex?: string;
   schema?: PartialJSONSchema7;
   description?: string;
@@ -202,7 +201,10 @@ export type Env0Api = {
   getOrganizations(): Promise<Organization[]>;
   getProjectsByOrganizationId(organizationId: string): Promise<Project[]>;
   getProjectById(projectId: string): Promise<Project>;
-  redeployEnvironment(environmentId: string, variables?: Variable[]): Promise<Deployment>;
+  redeployEnvironment(
+    environmentId: string,
+    variables?: Variable[],
+  ): Promise<Deployment>;
 };
 
 export type DeploymentStepStatus =

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -28,7 +28,7 @@ export type Env0VariablesInputProps = {
 };
 
 const shouldShowVariable = (variable: VariableWithEditScope) =>
-  !(variable.isReadonly || variable.isOutput);
+  !(variable.isReadonly || variable.schema?.format === 'ENVIRONMENT_OUTPUT');
 
 const VariableFields = ({
   variables,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
The 'isOutput' seems to be undefined for output variables, so we don't return it from our API

### Solution
Use the schema format which seems to be how we determine it
### QA
- [x] See that an output variable gets hidden

[//]: # (Explain how you tested this PR)