### PR TITLE
Feat: disable project selector when no template

### DIFF
--- a/plugins/backstage-plugin-env0/README.md
+++ b/plugins/backstage-plugin-env0/README.md
@@ -169,3 +169,7 @@ If you want to set const template id to filter by use
 ui:options:
   env0TemplateId: "uuid"
 ```
+
+> [!NOTE]
+> The project selector requires a template being selected,
+> either from `env0_template_id` or the `env0TemplateId` `ui:option`

--- a/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
@@ -80,7 +80,7 @@ export const Env0ProjectSelector = ({
 }: Env0ProjectSelectorFieldProps) => {
   const formTemplateId: string | undefined =
     formContext?.formData?.env0_template_id;
-  const rawUiSchemaTemplateId = uiSchema?.['ui:options']?.['env0TemplateId'];
+  const rawUiSchemaTemplateId = uiSchema?.['ui:options']?.env0TemplateId;
   const selectedTemplateId = formTemplateId || rawUiSchemaTemplateId;
   const { projects, error, loading } =
     useGetProjectsByTemplateId(selectedTemplateId);

--- a/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
@@ -100,6 +100,7 @@ export const Env0ProjectSelector = ({
       >
         <Autocomplete<Project>
           loading={loading}
+          disabled={!formTemplateId}
           getOptionLabel={option => option.name}
           options={projects}
           value={projects.find(p => p.id === selectedProjectId) || null}

--- a/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-project-selector/env0-project-selector.tsx
@@ -100,7 +100,7 @@ export const Env0ProjectSelector = ({
       >
         <Autocomplete<Project>
           loading={loading}
-          disabled={!formTemplateId}
+          disabled={!selectedTemplateId}
           getOptionLabel={option => option.name}
           options={projects}
           value={projects.find(p => p.id === selectedProjectId) || null}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
People can fill in whatever project the want before selecting a template,
and then select a template,

and we don't validate the template belongs to that project
### Solution
Disable the project selector as long as there's no template selected
### QA
<img width="751" alt="Screenshot 2024-12-26 at 10 19 48" src="https://github.com/user-attachments/assets/4163fb41-56ef-4148-816c-20dfcc92bfd9" />
<img width="287" alt="Screenshot 2024-12-26 at 10 19 54" src="https://github.com/user-attachments/assets/149e759d-b906-4259-9896-4fa3fdb03400" />

[//]: # (Explain how you tested this PR)