### PR TITLE
Feat: hide secret references

### DIFF
--- a/plugins/backstage-plugin-env0/src/api/client.ts
+++ b/plugins/backstage-plugin-env0/src/api/client.ts
@@ -18,6 +18,7 @@ import {
 
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { isNil, omitBy } from 'lodash';
+import { isSecretReference } from '../components/common/is-secret-reference';
 
 export type Env0ClientApiDependencies = {
   discoveryApi: DiscoveryApi;
@@ -76,7 +77,9 @@ export class Env0Client implements Env0Api {
       },
       nonNullVariableScopeParams,
     );
-    return variables.json();
+
+    const variablesData: Variable[] = await variables.json();
+    return variablesData.filter(variable => !isSecretReference(variable));
   }
 
   // https://docs.env0.com/reference/configuration-find-configuration-set-by-id

--- a/plugins/backstage-plugin-env0/src/api/client.ts
+++ b/plugins/backstage-plugin-env0/src/api/client.ts
@@ -153,9 +153,7 @@ export class Env0Client implements Env0Api {
       method: 'GET',
     });
     const projects: Project[] = await projectsResponse.json();
-    return projects.filter(
-      project => !project.isArchived,
-    );
+    return projects.filter(project => !project.isArchived);
   }
 
   // https://docs.env0.com/reference/environments-deploy

--- a/plugins/backstage-plugin-env0/src/components/common/is-secret-reference.ts
+++ b/plugins/backstage-plugin-env0/src/components/common/is-secret-reference.ts
@@ -1,0 +1,21 @@
+import { Variable } from '../../api/types';
+
+enum SecretReferencePrefixes {
+  AWS = 'ssm',
+  GCP = 'gcp',
+  AZURE = 'azure',
+  VAULT = 'vault',
+  OCI = 'oci',
+}
+const SECRET_REF_POSTFIX = '}';
+
+const getFullPrefix = (secretType: string) => `\${${secretType}:`;
+const startsWithPrefix = (reference: string | undefined, prefix: string) =>
+  reference?.startsWith(getFullPrefix(prefix));
+
+export const isSecretReference = (variable: Variable) =>
+  Object.values(SecretReferencePrefixes).some(
+    prefix =>
+      startsWithPrefix(variable.value, prefix) &&
+      variable.value?.endsWith(SECRET_REF_POSTFIX),
+  );


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We don't wanna show secret references in backstage, since users can't do anything with them here
### Solution
filter them out _**on the api level**_, to guarantee they won't appear anywhere.
### QA
- [x] create a reference in env0 but am not able to find it
this var
<img width="1075" alt="Screenshot 2024-12-26 at 15 01 10" src="https://github.com/user-attachments/assets/2d5cbd0a-eb8b-47f9-91e6-a8e1e7675def" />

is not here
<img width="188" alt="Screenshot 2024-12-26 at 15 01 20" src="https://github.com/user-attachments/assets/3135d63e-fe75-4fcf-824b-7e32bd2a20d2" />
