### PR TITLE
Fix: when error is object we don't show the content

### DIFF
--- a/plugins/scaffolder-backend-module-env0/src/actions/common/extract-api-error.ts
+++ b/plugins/scaffolder-backend-module-env0/src/actions/common/extract-api-error.ts
@@ -1,3 +1,7 @@
 export const extractApiError = (error: any) => {
-  return new Error(error.response?.data || error.message);
+  let errorMessage = error.response?.data || error.message;
+  if (errorMessage instanceof Object) {
+    errorMessage = JSON.stringify(errorMessage);
+  }
+  return new Error(errorMessage);
 };


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
When we get an error from env0 as a json object we log
```
32024-12-30T11:32:58.000Z error: Failed to create env0 environment42024-12-30T11:32:58.000Z Error: [object Object]
```
### Solution
Check if the message is object if so stringify it

### QA
Recreate the broken flow with unauthorized 

[//]: # (Explain how you tested this PR)