### PR TITLE
Chore: Add scaffolder actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   CI:
@@ -20,6 +20,7 @@ jobs:
         run: yarn tsc:full
       - name: Lint
         run: yarn lint:all
+      - name: Test
+        run: CI=true yarn test
       - name: Build Packages
         run: yarn build:all
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Compile TypeScript
         run: yarn tsc:full
-
+      - name: Test
+        run: CI=true yarn test
       - name: Build Packages
         run: yarn build:all
 

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
@@ -89,7 +89,7 @@ export const Env0DeploymentTable: React.FunctionComponent<{
   return (
     <Env0Card
       title="env0 Deployments"
-      subheader="View the history of deployments for this environment in env0."
+      subheader="View the last 50 deployments for this environment in env0."
       retryAction={retry}
       actions={
         <RedeployButton

--- a/plugins/scaffolder-backend-module-env0/src/actions/create-environment.test.ts
+++ b/plugins/scaffolder-backend-module-env0/src/actions/create-environment.test.ts
@@ -1,0 +1,135 @@
+import { createEnv0CreateEnvironmentAction } from './create-environment';
+import { apiClient } from './common/api-client';
+import { getEnv0EnvironmentUrl } from './common/get-urls';
+
+jest.mock('./common/api-client', () => ({
+  apiClient: {
+    createEnvironment: jest.fn(),
+  },
+}));
+
+jest.mock('./common/get-urls', () => ({
+  getEnv0EnvironmentUrl: jest.fn(),
+}));
+
+describe('create environment action', () => {
+  const mockContext = {
+    input: {
+      name: 'test-environment',
+      projectId: 'project-123',
+      templateId: 'template-456',
+      comment: 'Test deployment',
+      variables: [
+        {
+          id: 'var-1',
+          name: 'TEST_VAR',
+          value: 'test-value',
+        },
+      ],
+    },
+    output: jest.fn(),
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  } as any;
+
+  const mockEnvironmentResponse = {
+    id: 'env-789',
+    organizationId: 'org-123',
+  };
+
+  const mockEnvironmentUrl =
+    'https://app.env0.com/p/project-123/environments/env-789';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiClient.createEnvironment as jest.Mock).mockResolvedValue(
+      mockEnvironmentResponse,
+    );
+    (getEnv0EnvironmentUrl as jest.Mock).mockReturnValue(mockEnvironmentUrl);
+  });
+
+  it('should create an environment successfully', async () => {
+    const action = createEnv0CreateEnvironmentAction();
+    await action.handler(mockContext);
+
+    expect(apiClient.createEnvironment).toHaveBeenCalledWith({
+      name: mockContext.input.name,
+      projectId: mockContext.input.projectId,
+      configurationChanges: mockContext.input.variables,
+      deployRequest: {
+        comment: mockContext.input.comment,
+        blueprintId: mockContext.input.templateId,
+      },
+    });
+  });
+
+  it('should the environment values into the context output', async () => {
+    const action = createEnv0CreateEnvironmentAction();
+    await action.handler(mockContext);
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'environmentUrl',
+      mockEnvironmentUrl,
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'environmentId',
+      mockEnvironmentResponse.id,
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'organizationId',
+      mockEnvironmentResponse.organizationId,
+    );
+  });
+
+  it('should handle API errors', async () => {
+    const mockError = {
+      response: {
+        data: {
+          message: 'Invalid project ID',
+        },
+      },
+    };
+    (apiClient.createEnvironment as jest.Mock).mockRejectedValue(mockError);
+
+    const action = createEnv0CreateEnvironmentAction();
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      '{"message":"Invalid project ID"}',
+    );
+  });
+
+  it('should handle optional fields correctly', async () => {
+    const minimalContext = {
+      ...mockContext,
+      input: {
+        name: 'test-environment',
+        projectId: 'project-123',
+        templateId: 'template-456',
+      },
+    };
+
+    const action = createEnv0CreateEnvironmentAction();
+    await action.handler(minimalContext);
+
+    expect(apiClient.createEnvironment).toHaveBeenCalledWith({
+      name: minimalContext.input.name,
+      projectId: minimalContext.input.projectId,
+      configurationChanges: undefined,
+      deployRequest: {
+        comment: undefined,
+        blueprintId: minimalContext.input.templateId,
+      },
+    });
+  });
+
+  it('should throw error when environment creation fails without response data', async () => {
+    const mockError = new Error('Network error');
+    (apiClient.createEnvironment as jest.Mock).mockRejectedValue(mockError);
+
+    const action = createEnv0CreateEnvironmentAction();
+
+    await expect(action.handler(mockContext)).rejects.toThrow('Network error');
+  });
+});

--- a/plugins/scaffolder-backend-module-env0/src/actions/create-environment.test.ts
+++ b/plugins/scaffolder-backend-module-env0/src/actions/create-environment.test.ts
@@ -13,7 +13,7 @@ jest.mock('./common/get-urls', () => ({
 }));
 
 describe('create environment action', () => {
-  const mockContext = {
+  const mockPluginContext = {
     input: {
       name: 'test-environment',
       projectId: 'project-123',
@@ -52,32 +52,32 @@ describe('create environment action', () => {
 
   it('should create an environment successfully', async () => {
     const action = createEnv0CreateEnvironmentAction();
-    await action.handler(mockContext);
+    await action.handler(mockPluginContext);
 
     expect(apiClient.createEnvironment).toHaveBeenCalledWith({
-      name: mockContext.input.name,
-      projectId: mockContext.input.projectId,
-      configurationChanges: mockContext.input.variables,
+      name: mockPluginContext.input.name,
+      projectId: mockPluginContext.input.projectId,
+      configurationChanges: mockPluginContext.input.variables,
       deployRequest: {
-        comment: mockContext.input.comment,
-        blueprintId: mockContext.input.templateId,
+        comment: mockPluginContext.input.comment,
+        blueprintId: mockPluginContext.input.templateId,
       },
     });
   });
 
-  it('should the environment values into the context output', async () => {
+  it('should add the environment values into the context output', async () => {
     const action = createEnv0CreateEnvironmentAction();
-    await action.handler(mockContext);
+    await action.handler(mockPluginContext);
 
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'environmentUrl',
       mockEnvironmentUrl,
     );
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'environmentId',
       mockEnvironmentResponse.id,
     );
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'organizationId',
       mockEnvironmentResponse.organizationId,
     );
@@ -95,14 +95,14 @@ describe('create environment action', () => {
 
     const action = createEnv0CreateEnvironmentAction();
 
-    await expect(action.handler(mockContext)).rejects.toThrow(
+    await expect(action.handler(mockPluginContext)).rejects.toThrow(
       '{"message":"Invalid project ID"}',
     );
   });
 
   it('should handle optional fields correctly', async () => {
     const minimalContext = {
-      ...mockContext,
+      ...mockPluginContext,
       input: {
         name: 'test-environment',
         projectId: 'project-123',
@@ -130,6 +130,8 @@ describe('create environment action', () => {
 
     const action = createEnv0CreateEnvironmentAction();
 
-    await expect(action.handler(mockContext)).rejects.toThrow('Network error');
+    await expect(action.handler(mockPluginContext)).rejects.toThrow(
+      'Network error',
+    );
   });
 });

--- a/plugins/scaffolder-backend-module-env0/src/actions/redeploy-environment.test.ts
+++ b/plugins/scaffolder-backend-module-env0/src/actions/redeploy-environment.test.ts
@@ -1,0 +1,157 @@
+import { createEnv0RedeployEnvironmentAction } from './redeploy-environment';
+import { apiClient } from './common/api-client';
+import { getEnv0DeploymentUrl } from './common/get-urls';
+
+jest.mock('./common/api-client', () => ({
+  apiClient: {
+    redeployEnvironment: jest.fn(),
+    getEnvironment: jest.fn(),
+  },
+}));
+
+jest.mock('./common/get-urls', () => ({
+  getEnv0DeploymentUrl: jest.fn(),
+}));
+
+describe('redeploy environment action', () => {
+  const mockContext = {
+    input: {
+      id: 'env-123',
+      comment: 'Test redeployment',
+      variables: [
+        {
+          id: 'var-1',
+          name: 'TEST_VAR',
+          value: 'test-value',
+        },
+      ],
+    },
+    output: jest.fn(),
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  } as any;
+
+  const mockRedeployResponse = {
+    id: 'deploy-789',
+  };
+
+  const mockEnvironmentResponse = {
+    projectId: 'project-123',
+  };
+
+  const mockDeploymentUrl =
+    'https://app.env0.com/p/project-123/environments/env-123/deployments/deploy-789';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiClient.redeployEnvironment as jest.Mock).mockResolvedValue(
+      mockRedeployResponse,
+    );
+    (apiClient.getEnvironment as jest.Mock).mockResolvedValue(
+      mockEnvironmentResponse,
+    );
+    (getEnv0DeploymentUrl as jest.Mock).mockReturnValue(mockDeploymentUrl);
+  });
+
+  it('should redeploy an environment successfully', async () => {
+    const action = createEnv0RedeployEnvironmentAction();
+    await action.handler(mockContext);
+
+    expect(apiClient.redeployEnvironment).toHaveBeenCalledWith(
+      mockContext.input.id,
+      {
+        deployRequest: {
+          comment: mockContext.input.comment,
+          configurationChanges: mockContext.input.variables,
+        },
+      },
+    );
+
+    expect(apiClient.getEnvironment).toHaveBeenCalledWith(mockContext.input.id);
+  });
+
+  it('should set the deployment values in the context output', async () => {
+    const action = createEnv0RedeployEnvironmentAction();
+    await action.handler(mockContext);
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'deploymentUrl',
+      mockDeploymentUrl,
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'environmentId',
+      mockContext.input.id,
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'deploymentId',
+      mockRedeployResponse.id,
+    );
+  });
+
+  it('should handle redeploy API errors', async () => {
+    const mockError = {
+      response: {
+        data: {
+          message: 'Invalid environment ID',
+        },
+      },
+    };
+    (apiClient.redeployEnvironment as jest.Mock).mockRejectedValue(mockError);
+
+    const action = createEnv0RedeployEnvironmentAction();
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      '{"message":"Invalid environment ID"}',
+    );
+  });
+
+  it('should handle get environment API errors', async () => {
+    const mockError = {
+      response: {
+        data: {
+          message: 'Failed to get environment',
+        },
+      },
+    };
+    (apiClient.getEnvironment as jest.Mock).mockRejectedValue(mockError);
+
+    const action = createEnv0RedeployEnvironmentAction();
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      '{"message":"Failed to get environment"}',
+    );
+  });
+
+  it('should handle optional fields correctly', async () => {
+    const minimalContext = {
+      ...mockContext,
+      input: {
+        id: 'env-123',
+      },
+    };
+
+    const action = createEnv0RedeployEnvironmentAction();
+    await action.handler(minimalContext);
+
+    expect(apiClient.redeployEnvironment).toHaveBeenCalledWith(
+      minimalContext.input.id,
+      {
+        deployRequest: {
+          comment: undefined,
+          configurationChanges: undefined,
+        },
+      },
+    );
+  });
+
+  it('should throw error when redeployment fails without response data', async () => {
+    const mockError = new Error('Network error');
+    (apiClient.redeployEnvironment as jest.Mock).mockRejectedValue(mockError);
+
+    const action = createEnv0RedeployEnvironmentAction();
+
+    await expect(action.handler(mockContext)).rejects.toThrow('Network error');
+  });
+});

--- a/plugins/scaffolder-backend-module-env0/src/actions/redeploy-environment.test.ts
+++ b/plugins/scaffolder-backend-module-env0/src/actions/redeploy-environment.test.ts
@@ -14,7 +14,7 @@ jest.mock('./common/get-urls', () => ({
 }));
 
 describe('redeploy environment action', () => {
-  const mockContext = {
+  const mockPluginContext = {
     input: {
       id: 'env-123',
       comment: 'Test redeployment',
@@ -57,34 +57,36 @@ describe('redeploy environment action', () => {
 
   it('should redeploy an environment successfully', async () => {
     const action = createEnv0RedeployEnvironmentAction();
-    await action.handler(mockContext);
+    await action.handler(mockPluginContext);
 
     expect(apiClient.redeployEnvironment).toHaveBeenCalledWith(
-      mockContext.input.id,
+      mockPluginContext.input.id,
       {
         deployRequest: {
-          comment: mockContext.input.comment,
-          configurationChanges: mockContext.input.variables,
+          comment: mockPluginContext.input.comment,
+          configurationChanges: mockPluginContext.input.variables,
         },
       },
     );
 
-    expect(apiClient.getEnvironment).toHaveBeenCalledWith(mockContext.input.id);
+    expect(apiClient.getEnvironment).toHaveBeenCalledWith(
+      mockPluginContext.input.id,
+    );
   });
 
   it('should set the deployment values in the context output', async () => {
     const action = createEnv0RedeployEnvironmentAction();
-    await action.handler(mockContext);
+    await action.handler(mockPluginContext);
 
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'deploymentUrl',
       mockDeploymentUrl,
     );
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'environmentId',
-      mockContext.input.id,
+      mockPluginContext.input.id,
     );
-    expect(mockContext.output).toHaveBeenCalledWith(
+    expect(mockPluginContext.output).toHaveBeenCalledWith(
       'deploymentId',
       mockRedeployResponse.id,
     );
@@ -102,7 +104,7 @@ describe('redeploy environment action', () => {
 
     const action = createEnv0RedeployEnvironmentAction();
 
-    await expect(action.handler(mockContext)).rejects.toThrow(
+    await expect(action.handler(mockPluginContext)).rejects.toThrow(
       '{"message":"Invalid environment ID"}',
     );
   });
@@ -119,14 +121,14 @@ describe('redeploy environment action', () => {
 
     const action = createEnv0RedeployEnvironmentAction();
 
-    await expect(action.handler(mockContext)).rejects.toThrow(
+    await expect(action.handler(mockPluginContext)).rejects.toThrow(
       '{"message":"Failed to get environment"}',
     );
   });
 
   it('should handle optional fields correctly', async () => {
     const minimalContext = {
-      ...mockContext,
+      ...mockPluginContext,
       input: {
         id: 'env-123',
       },
@@ -152,6 +154,8 @@ describe('redeploy environment action', () => {
 
     const action = createEnv0RedeployEnvironmentAction();
 
-    await expect(action.handler(mockContext)).rejects.toThrow('Network error');
+    await expect(action.handler(mockPluginContext)).rejects.toThrow(
+      'Network error',
+    );
   });
 });


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We want to add more tests in addition to the ones in #[58](https://github.com/env0/env0-backstage-plugin/pull/58)
for the scaffolder actions and also add a GH action to run the tests
### Solution
Add the tests and CI step
### QA
Saw that tests are passing locally
