### PR TITLE
Fix: Long variable names are overlapped

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
@@ -28,7 +28,7 @@ const StyledBox = styled(Box)({
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: '50%',
+  width: '80%',
 });
 
 export const RedeployButton: React.FC<{

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -12,7 +12,7 @@ import type { Variable } from '../../api/types';
 
 const VariableContainer = styled('div')(() => ({
   display: 'grid',
-  gridTemplateColumns: '1.5fr 5.5fr',
+  gridTemplateColumns: '3fr 11fr',
   gridColumnStart: 1,
   gap: '2em',
   alignItems: 'center',

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -12,7 +12,7 @@ import type { Variable } from '../../api/types';
 
 const VariableContainer = styled('div')(() => ({
   display: 'grid',
-  gridTemplateColumns: '1fr 5fr',
+  gridTemplateColumns: '1.5fr 5.5fr',
   gridColumnStart: 1,
   gap: '2em',
   alignItems: 'center',

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -31,6 +31,13 @@ const InputAndInfoIconContainer = styled('div')(() => ({
   alignItems: 'center',
 }));
 
+const EllipsisTypography = styled(Typography)(() => ({
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}));
+
 type VariableType = 'string' | 'dropdown';
 
 type VariableInputComponentProps = {
@@ -118,12 +125,11 @@ export const Env0VariableField = ({
 }: VariableInputComponentProps) => {
   return (
     <VariableContainer data-testid={`${variable.id}-variable-field`}>
-      <Typography
-        noWrap={false}
+      <EllipsisTypography
+        noWrap
         variant="body1"
         style={{
-          display: 'flex',
-          minWidth: '150px',
+          maxWidth: '100%',
           fontWeight: 'bold',
         }}
       >
@@ -133,7 +139,7 @@ export const Env0VariableField = ({
           </Tooltip>
         )}
         {variable.name}:
-      </Typography>
+      </EllipsisTypography>
       <InputAndInfoIconContainer>
         {getVariableInput(variable, onVariableUpdated)}
         {variable.description && (

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -138,7 +138,10 @@ export const Env0VariableField = ({
             <Warning />
           </Tooltip>
         )}
-        {variable.name}:
+        <Tooltip title={variable.name} placement="top-start">
+          <span>{variable.name}</span>
+        </Tooltip>
+        :
       </EllipsisTypography>
       <InputAndInfoIconContainer>
         {getVariableInput(variable, onVariableUpdated)}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
When we have long variable name they are overlapping on the value
### Solution
Add ellipsis
Add tooltip for the full name
### QA

On scaffolder create 
![image](https://github.com/user-attachments/assets/1588c293-b32f-4b8b-bdcc-48a9f35cb220)

On redeploy
![image](https://github.com/user-attachments/assets/3da324ed-7334-487b-bf77-bff8a55de0d1)
