### PR TITLE
Fix: Add variable validation for redeploying environments

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.test.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.test.tsx
@@ -299,7 +299,6 @@ describe('RedeployButton', () => {
       });
 
       it('should allow deployment when all validation passes', async () => {
-        jestPreview.debug();
         await editVariable(regexVariableId, '25');
         const deployButton = await screen.findByTestId('redeploy-run-button');
         await userEvent.click(deployButton);

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.test.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.test.tsx
@@ -285,7 +285,7 @@ describe('RedeployButton', () => {
       });
 
       it('should show validation errors when regex validation fails', async () => {
-        await editVariable(regexVariableId, '25');
+        await editVariable(regexVariableId, '55');
         const deployButton = await screen.findByTestId('redeploy-run-button');
         await userEvent.click(deployButton);
 

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
@@ -15,6 +15,8 @@ import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import useAsync from 'react-use/lib/useAsync';
 import type { Variable } from '../../api/types';
+import { useVariablesValidation } from './use-variables-validation';
+import Alert from '@mui/material/Alert';
 
 const StyledCard = styled(Card)({
   padding: '0 1em',
@@ -45,6 +47,8 @@ export const RedeployButton: React.FC<{
   const [snackBarOpen, setSnackBarOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [variables, setVariables] = useState<Variable[]>([]);
+  const { validationErrors } = useVariablesValidation({ variables });
+  const [hasAttemptedDeploy, setHasAttemptedDeploy] = useState(false);
 
   const {
     value,
@@ -69,6 +73,7 @@ export const RedeployButton: React.FC<{
 
   const handleModalClose = () => {
     setModalOpen(false);
+    setHasAttemptedDeploy(false);
   };
 
   const handleSnackbarClose = (
@@ -84,6 +89,12 @@ export const RedeployButton: React.FC<{
 
   const handleRedeploy = async () => {
     if (!environmentId) {
+      return;
+    }
+
+    setHasAttemptedDeploy(true);
+
+    if (validationErrors.length > 0) {
       return;
     }
 
@@ -117,9 +128,16 @@ export const RedeployButton: React.FC<{
     >
       <StyledBox>
         <StyledCard>
+          {validationErrors.length > 0 && hasAttemptedDeploy && (
+            <Alert severity="error" elevation={6} variant="filled">
+              {validationErrors.map((error, index) => (
+                <div key={index}>{error}</div>
+              ))}
+            </Alert>
+          )}
           <StyledEnv0VariablesInput
             onVariablesFormDataChange={setVariables}
-            rawErrors={[]}
+            rawErrors={validationErrors}
             environmentId={environmentId}
             projectId={projectId}
             templateId={templateId}

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/redeploy-button.tsx
@@ -15,7 +15,6 @@ import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import useAsync from 'react-use/lib/useAsync';
 import type { Variable } from '../../api/types';
-import { useVariablesValidation } from './use-variables-validation';
 import Alert from '@mui/material/Alert';
 
 const StyledCard = styled(Card)({
@@ -47,7 +46,7 @@ export const RedeployButton: React.FC<{
   const [snackBarOpen, setSnackBarOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [variables, setVariables] = useState<Variable[]>([]);
-  const { validationErrors } = useVariablesValidation({ variables });
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [hasAttemptedDeploy, setHasAttemptedDeploy] = useState(false);
 
   const {
@@ -106,7 +105,7 @@ export const RedeployButton: React.FC<{
       setSnackbarText('Failed to trigger env0 deployment ❌');
     } finally {
       setSnackBarOpen(true);
-      setModalOpen(false);
+      handleModalClose();
       setIsRedeploying(false);
       afterDeploy?.();
     }
@@ -129,7 +128,12 @@ export const RedeployButton: React.FC<{
       <StyledBox>
         <StyledCard>
           {validationErrors.length > 0 && hasAttemptedDeploy && (
-            <Alert severity="error" elevation={6} variant="filled">
+            <Alert
+              data-testid="redeploy-validation-errors"
+              severity="error"
+              elevation={6}
+              variant="filled"
+            >
               {validationErrors.map((error, index) => (
                 <div key={index}>{error}</div>
               ))}
@@ -137,7 +141,7 @@ export const RedeployButton: React.FC<{
           )}
           <StyledEnv0VariablesInput
             onVariablesFormDataChange={setVariables}
-            rawErrors={validationErrors}
+            editRawErrors={setValidationErrors}
             environmentId={environmentId}
             projectId={projectId}
             templateId={templateId}
@@ -147,7 +151,7 @@ export const RedeployButton: React.FC<{
               data-testid="redeploy-cancel-button"
               color="secondary"
               variant="contained"
-              onClick={() => setModalOpen(false)}
+              onClick={() => handleModalClose()}
             >
               Cancel
             </Button>

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/use-variables-validation.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/use-variables-validation.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { Variable } from '../../api/types';
 import { doesVariableValueMatchRegex } from '../env0-variables-input/env0-variable-field';
+import { VariableWithEditScope } from '../env0-variables-input';
+import uniqBy from 'lodash/uniqBy';
 
 const validateVariables = (variables: Variable[]): string[] => {
   const errors: string[] = [];
   variables.forEach(variable => {
-    if (variable.isRequired && !variable.value) {
+    if (variable.isRequired && !variable.value && !variable.isSensitive) {
       errors.push(`Variable "${variable.name}" is required`);
     }
     if (!doesVariableValueMatchRegex(variable)) {
@@ -18,15 +20,23 @@ const validateVariables = (variables: Variable[]): string[] => {
 };
 
 export const useVariablesValidation = ({
-  variables,
+  editedVariables,
+  variablesData,
 }: {
-  variables: Variable[];
+  editedVariables: VariableWithEditScope[];
+  variablesData?: Variable[];
 }) => {
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
   useEffect(() => {
-    setValidationErrors(validateVariables(variables));
-  }, [variables]);
+    if (variablesData) {
+      const distinctVariables = uniqBy(
+        [...editedVariables, ...variablesData],
+        'id',
+      );
+      setValidationErrors(validateVariables(distinctVariables));
+    }
+  }, [editedVariables, variablesData]);
 
   return { validationErrors };
 };

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/use-variables-validation.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/use-variables-validation.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { Variable } from '../../api/types';
+import { doesVariableValueMatchRegex } from '../env0-variables-input/env0-variable-field';
+
+const validateVariables = (variables: Variable[]): string[] => {
+  const errors: string[] = [];
+  variables.forEach(variable => {
+    if (variable.isRequired && !variable.value) {
+      errors.push(`Variable "${variable.name}" is required`);
+    }
+    if (!doesVariableValueMatchRegex(variable)) {
+      errors.push(
+        `Value for variable "${variable.name}" does not match regex: ${variable.regex}`,
+      );
+    }
+  });
+  return errors;
+};
+
+export const useVariablesValidation = ({
+  variables,
+}: {
+  variables: Variable[];
+}) => {
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    setValidationErrors(validateVariables(variables));
+  }, [variables]);
+
+  return { validationErrors };
+};

--- a/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-environment-details-card/env0-environment-details-card.tsx
@@ -104,8 +104,11 @@ export const Env0EnvironmentDetailsCard = () => {
       <CardActions>
         <Button color="primary" variant="contained">
           <Link
-            to={getEnv0EnvironmentUrl({ environmentId: environment.id, projectId: environment.projectId })}
-            color="textPrimary"
+            to={getEnv0EnvironmentUrl({
+              environmentId: environment.id,
+              projectId: environment.projectId,
+            })}
+            color="inherit"
           >
             Open in env0
           </Link>

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -61,9 +61,7 @@ export const doesVariableValueMatchRegex = (variable: Variable) => {
 const getVariableHelperText = (
   isRegexWrong: boolean,
   isRequiredValueMissing: undefined | boolean,
-  variable: VariableFields & {
-    overwrites?: VariableFields;
-  },
+  variable: VariableFields,
 ) => {
   if (isRegexWrong) {
     return `Value does not match regex: ${variable.regex}`;

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -8,7 +8,7 @@ import {
 import Warning from '@material-ui/icons/Warning';
 import InfoRounded from '@material-ui/icons/InfoRounded';
 import React, { ReactElement } from 'react';
-import type { Variable } from '../../api/types';
+import type { Variable, VariableFields } from '../../api/types';
 
 const VariableContainer = styled('div')(() => ({
   display: 'grid',
@@ -58,12 +58,30 @@ export const doesVariableValueMatchRegex = (variable: Variable) => {
   return regex.test(variable.value || '');
 };
 
+const getVariableHelperText = (
+  isRegexWrong: boolean,
+  isRequiredValueMissing: undefined | boolean,
+  variable: VariableFields & {
+    overwrites?: VariableFields;
+  },
+) => {
+  if (isRegexWrong) {
+    return `Value does not match regex: ${variable.regex}`;
+  }
+  if (isRequiredValueMissing) {
+    return 'Value is required';
+  }
+  return '';
+};
+
 const variableInputByInputType: Record<
   VariableType,
   ({ variable, onVariableUpdated }: VariableInputComponentProps) => ReactElement
 > = {
   string: ({ variable, onVariableUpdated }) => {
     const isRegexWrong = !doesVariableValueMatchRegex(variable);
+    const isRequiredValueMissing =
+      variable.isRequired && !variable.value && !variable.isSensitive;
 
     const onlyAsterisks = /^\*+$/;
     const isVariableValueSecretMask =
@@ -77,10 +95,12 @@ const variableInputByInputType: Record<
         value={variable.value}
         placeholder={isVariableValueSecretMask ? '********' : ''}
         required={variable.isRequired}
-        error={isRegexWrong}
-        helperText={
-          isRegexWrong ? `Value does not match regex: ${variable.regex}` : ''
-        }
+        error={isRegexWrong || isRequiredValueMissing}
+        helperText={getVariableHelperText(
+          isRegexWrong,
+          isRequiredValueMissing,
+          variable,
+        )}
         onChange={(changeEvent: React.ChangeEvent<{ value: string }>) =>
           onVariableUpdated(
             variable,

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-input.tsx
@@ -13,7 +13,7 @@ import { Progress } from '@backstage/core-components';
 import { ErrorContainer } from '../common/error-container';
 import { Env0VariableField } from './env0-variable-field';
 import { useVariablesData } from '../../hooks/use-variables-data';
-import { useVariablesValidation } from '../env0-deployment-table/use-variables-validation';
+import { useVariablesValidation } from '../../hooks/use-variables-validation';
 
 export type VariableWithEditScope = Variable & {
   isEdited?: boolean;

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variables-scaffolder-input.tsx
@@ -30,7 +30,6 @@ type Env0TemplateSelectorFieldProps =
 
 export const Env0VariablesScaffolderInput = ({
   formContext,
-  rawErrors,
   onChange: onVariablesFormChange,
 }: Env0TemplateSelectorFieldProps): React.ReactElement => {
   const {
@@ -39,7 +38,6 @@ export const Env0VariablesScaffolderInput = ({
   return (
     <Env0VariablesInput
       onVariablesFormDataChange={onVariablesFormChange}
-      rawErrors={rawErrors}
       projectId={projectId}
       templateId={templateId}
     />

--- a/plugins/backstage-plugin-env0/src/hooks/use-variables-validation.tsx
+++ b/plugins/backstage-plugin-env0/src/hooks/use-variables-validation.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Variable } from '../../api/types';
-import { doesVariableValueMatchRegex } from '../env0-variables-input/env0-variable-field';
-import { VariableWithEditScope } from '../env0-variables-input';
+import { Variable } from '../api/types';
+import { doesVariableValueMatchRegex } from '../components/env0-variables-input/env0-variable-field';
+import { VariableWithEditScope } from '../components/env0-variables-input';
 import uniqBy from 'lodash/uniqBy';
 
 const validateVariables = (variables: Variable[]): string[] => {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We didn't run validations for our variables allowing values to pass through and not show the errors for it

### Solution
Add validations and make it look similar to how our validations look in the create form
![chrome-capture-2024-11-31](https://github.com/user-attachments/assets/beba47b1-60dd-4649-ba20-93e51366d88f)

### QA
- [x] Add regex variables see form behaves as expected
- [x] Add required variable see that we validate and show error on it
