### PR TITLE
Feat: Show deployment comment in deployment history table

### DIFF
--- a/plugins/backstage-plugin-env0/src/api/types.d.ts
+++ b/plugins/backstage-plugin-env0/src/api/types.d.ts
@@ -127,6 +127,7 @@ export interface Deployment {
   blueprintRevision: string;
   blueprintRepository: string;
   blueprintId: string;
+  comment?: string;
 }
 
 type PartialJSONSchema7 = {

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.test.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.test.tsx
@@ -34,6 +34,7 @@ const mockDeployments: Deployment[] = [
     blueprintId: 'template-1',
     blueprintRepository: 'https://github.com/org/repo',
     blueprintRevision: 'main',
+    comment: 'deployment comment',
   },
 ];
 
@@ -130,13 +131,14 @@ describe('Env0DeploymentTable', () => {
     expect(await screen.findByText(/Test error/i)).toBeInTheDocument();
   });
 
-  it('displays deployment history in table', async () => {
+  it('displays deployment history in table with columns data', async () => {
     await renderComponent();
 
     expect(screen.getByText('Success')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('Jan 1, 2024, 10:00 AM')).toBeInTheDocument();
     expect(screen.getByText('00:30:00')).toBeInTheDocument();
+    expect(screen.getByText('deployment comment')).toBeInTheDocument();
   });
 
   it('shows deployment error when present', async () => {

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
@@ -72,11 +72,12 @@ const deploymentHistoryColumns: TableColumn<Deployment>[] = [
   },
   {
     title: 'Comment',
-    render: (deployment: Deployment) => (
-      <Tooltip title={deployment.comment}>
-        <EllipsisTypography>{deployment.comment}</EllipsisTypography>
-      </Tooltip>
-    ),
+    render: (deployment: Deployment) =>
+      deployment.comment && (
+        <Tooltip title={deployment.comment}>
+          <EllipsisTypography>{deployment.comment}</EllipsisTypography>
+        </Tooltip>
+      ),
   },
 ];
 

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
@@ -103,7 +103,7 @@ export const Env0DeploymentTable: React.FunctionComponent<{
   if (error) {
     return <ErrorContainer error={error} />;
   }
-  if (deployments) console.log('comment: ', deployments[0]?.comment);
+
   return (
     <Env0Card
       title="env0 Deployments"

--- a/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-deployment-table/env0-deployment-table.tsx
@@ -13,6 +13,8 @@ import { RedeployButton } from './redeploy-button';
 import { ResourceCount } from './resource-count';
 import { useGetEnvironmentById } from '../../hooks/use-get-environment';
 import { DeploymentErrorContainer } from './deployment-error-container';
+import { styled, Typography } from '@material-ui/core';
+import Tooltip from '@mui/material/Tooltip';
 
 const getFormattedDeploymentDuration = (deployment: Deployment) => {
   if (!deployment.finishedAt || !deployment.startedAt) return '-';
@@ -21,6 +23,14 @@ const getFormattedDeploymentDuration = (deployment: Deployment) => {
     .asSeconds();
   return parseTimerElapsedTime(durationInSeconds);
 };
+
+const EllipsisTypography = styled(Typography)(() => ({
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  width: '20em',
+}));
 
 const deploymentHistoryColumns: TableColumn<Deployment>[] = [
   {
@@ -60,6 +70,14 @@ const deploymentHistoryColumns: TableColumn<Deployment>[] = [
       <div>{getFormattedDeploymentDuration(deployment)}</div>
     ),
   },
+  {
+    title: 'Comment',
+    render: (deployment: Deployment) => (
+      <Tooltip title={deployment.comment}>
+        <EllipsisTypography>{deployment.comment}</EllipsisTypography>
+      </Tooltip>
+    ),
+  },
 ];
 
 export const Env0DeploymentTable: React.FunctionComponent<{
@@ -85,7 +103,7 @@ export const Env0DeploymentTable: React.FunctionComponent<{
   if (error) {
     return <ErrorContainer error={error} />;
   }
-
+  if (deployments) console.log('comment: ', deployments[0]?.comment);
   return (
     <Env0Card
       title="env0 Deployments"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We want to show the users the deployment comment
### Solution
Add it as a column to the table

### QA

[//]: # (Explain how you tested this PR)

![image](https://github.com/user-attachments/assets/3660edcd-1ab0-404c-8ecf-900a008c81ca)
![image](https://github.com/user-attachments/assets/cd56131d-2865-489c-8531-2741ee430ceb)
