### PR TITLE
Chore: Wrong yarn command in README

### DIFF
--- a/plugins/backstage-plugin-env0/README.md
+++ b/plugins/backstage-plugin-env0/README.md
@@ -16,7 +16,7 @@ Please refer to the root [README](https://github.com/env0/env0-backstage-plugin/
 ### 1. Install the plugin in your Backstage instance:
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/app @env0/backstage-plugin-env0
+yarn --cwd packages/app add @env0/backstage-plugin-env0
 ```
 
 ### 2. Add the env0 tab component to `EntityPage.tsx`:

--- a/plugins/scaffolder-backend-module-env0/README.md
+++ b/plugins/scaffolder-backend-module-env0/README.md
@@ -11,7 +11,7 @@ Please refer to the root [README](https://github.com/env0/env0-backstage-plugin/
 #### 1. Install the plugin into your Backstage instance:
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/backend @env0/backstage-scaffolder-backend-env0
+yarn --cwd packages/backend add @env0/backstage-scaffolder-backend-env0
 ```
 
 #### 2. Configure the plugin in your Backstage instance ([docs](https://backstage.io/docs/features/software-templates/writing-custom-actions/#registering-custom-actions)):


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
The syntax of the `yarn` install command in the readmes is wrong

### Solution
Fix it

### QA
See that the command works

[//]: # (Explain how you tested this PR)