### PR TITLE
Fix: sensitive variables resets on rerender issue 

### DIFF
--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.test.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Env0VariableField } from './env0-variable-field';
 import type { Variable } from '../../api/types';
-import jestPreview from 'jest-preview';
 
 describe('Env0VariableField', () => {
   beforeEach(() => {
@@ -77,7 +76,6 @@ describe('Env0VariableField', () => {
 
     const select = screen.getByRole('button');
     await userEvent.click(select);
-    jestPreview.debug();
     expect(select).toBeInTheDocument();
     expect(screen.getAllByRole('option')).toHaveLength(3);
   });

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.test.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Env0VariableField } from './env0-variable-field';
+import type { Variable } from '../../api/types';
+import jestPreview from 'jest-preview';
+
+describe('Env0VariableField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const defaultVariable: Variable = {
+    id: 'test-1',
+    name: 'TEST_VAR',
+    value: 'test-value',
+    scope: 'ENVIRONMENT',
+  };
+
+  const renderComponent = (props = {}) => {
+    const onVariableUpdated = jest.fn();
+    const variable = { ...defaultVariable, ...props };
+    return {
+      onVariableUpdated,
+      ...render(
+        <Env0VariableField
+          variable={variable}
+          onVariableUpdated={onVariableUpdated}
+        />,
+      ),
+    };
+  };
+
+  it('handles sensitive variables correctly', async () => {
+    const { onVariableUpdated } = renderComponent({
+      isSensitive: true,
+      value: '********',
+    });
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'new-secret');
+
+    expect(onVariableUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isSensitive: true,
+      }),
+      'new-secret',
+      true,
+    );
+  });
+
+  it('validates regex correctly', () => {
+    renderComponent({
+      value: 'abc123',
+      regex: '^[a-z0-9]+$',
+    });
+
+    expect(screen.queryByText(/does not match regex/i)).not.toBeInTheDocument();
+
+    renderComponent({
+      value: 'ABC',
+      regex: '^[a-z0-9]+$',
+    });
+
+    expect(screen.getByText(/does not match regex/i)).toBeInTheDocument();
+  });
+
+  it('handles dropdown variables correctly', async () => {
+    const schema = {
+      enum: ['option1', 'option2', 'option3'],
+    };
+
+    renderComponent({
+      schema,
+      value: 'option1',
+    });
+
+    const select = screen.getByRole('button');
+    await userEvent.click(select);
+    jestPreview.debug();
+    expect(select).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+});

--- a/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
+++ b/plugins/backstage-plugin-env0/src/components/env0-variables-input/env0-variable-field.tsx
@@ -85,14 +85,14 @@ const variableInputByInputType: Record<
     const isVariableValueSecretMask =
       variable.isSensitive && onlyAsterisks.test(variable.value || '');
 
-    variable.value = isVariableValueSecretMask ? undefined : variable.value;
+    const displayValue = isVariableValueSecretMask ? undefined : variable.value;
 
     return (
       <TextField
         fullWidth
-        value={variable.value}
+        value={displayValue}
         placeholder={isVariableValueSecretMask ? '********' : ''}
-        required={variable.isRequired}
+        required={variable.isRequired && !isVariableValueSecretMask}
         error={isRegexWrong || isRequiredValueMissing}
         helperText={getVariableHelperText(
           isRegexWrong,
@@ -103,7 +103,7 @@ const variableInputByInputType: Record<
           onVariableUpdated(
             variable,
             changeEvent.target.value,
-            !(isVariableValueSecretMask && variable.value === undefined),
+            !!changeEvent.target.value,
           )
         }
       />


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We have an issue where the sensitive variable value gets unset on a rerender, this is since we mutate the value on the render

### Solution
Make it so we don't mutate the sensitive variables on a rerender and add tests for it
### QA
- [x] See that sensitive variables are not reset and that editing them works as expected
![chrome-capture-2025-0-2](https://github.com/user-attachments/assets/cb57105b-dd9a-4935-bb83-85b15d8a90ef)
