### PR TITLE
Chore: fix example entityPage and add env details to readme

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -134,7 +134,11 @@ const entityWarningContent = (
 const overviewContent = (
   <>
     {entityWarningContent}
-    <Env0EnvironmentDetailsCard />
+    <EntitySwitch>
+      <EntitySwitch.Case if={entity => isEnv0Available(entity)}>
+        <Env0EnvironmentDetailsCard />
+      </EntitySwitch.Case>
+    </EntitySwitch>
   </>
 );
 

--- a/plugins/backstage-plugin-env0/README.md
+++ b/plugins/backstage-plugin-env0/README.md
@@ -25,9 +25,9 @@ yarn --cwd packages/app add @env0/backstage-plugin-env0
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx
 import {
-  env0TabComponent,
-  isenv0Available,
-  env0EnvironmentDetailsCard,
+  Env0TabComponent,
+  isEnv0Available,
+  Env0EnvironmentDetailsCard,
 } from '@env0/backstage-plugin-env0';
 ```
 
@@ -42,7 +42,18 @@ import {
   <Env0TabComponent />
 </EntityLayout.Route>
 ```
-### 3. Provide the env0 proxy configuration in `app-config.yaml`:
+
+### 3. Add the env0 details component to `EntityPage.tsx`:
+#### Add the env0 details component to the `overviewPage` constant:
+```tsx
+// In packages/app/src/components/catalog/EntityPage.tsx
+<EntitySwitch>
+  <EntitySwitch.Case if={entity => isEnv0Available(entity)}>
+    <Env0EnvironmentDetailsCard />
+  </EntitySwitch.Case>
+</EntitySwitch>
+```
+### 4. Provide the env0 proxy configuration in `app-config.yaml`:
 ```yaml
 proxy:
   '/env0':


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Noticed that we are trying to show env details on every component in our example and that we don't have the env details in our docs
### Solution
Fix the entity page to only show for env0 components and add to readme
### QA
- [x] See that we are not trying to show the env0 details for the example component
